### PR TITLE
When using the FCloudStoragePropertyResource to download a file, the

### DIFF
--- a/foc/src/com/foc/property/FCloudStoragePropertyResource.java
+++ b/foc/src/com/foc/property/FCloudStoragePropertyResource.java
@@ -48,7 +48,7 @@ public class FCloudStoragePropertyResource implements ConnectorResource {
 	    
 	    if(is != null){
 	      downloadStream = new DownloadStream(is, "application/x-unknown", cloudStorageProperty.getFileName());
-	      downloadStream.setParameter("Content-Disposition", "attachment; filename=" + cloudStorageProperty.getFileName());
+	      downloadStream.setParameter("Content-Disposition", "attachment; filename=" + DownloadStream.getContentDispositionFilename(cloudStorageProperty.getFileName()));
 	      downloadStream.setCacheTime(0);  
 	    }
     }


### PR DESCRIPTION
name is formtted according to UTF-8