### PR TITLE
After change status - rebuild XML

### DIFF
--- a/focWebServer/src/com/foc/vaadin/gui/layouts/validationLayout/FVStatusLayout_MenuBar.java
+++ b/focWebServer/src/com/foc/vaadin/gui/layouts/validationLayout/FVStatusLayout_MenuBar.java
@@ -190,6 +190,7 @@ public class FVStatusLayout_MenuBar extends MenuBar {
 							xmlLayout.getValidationLayout().commit();
 						}
 						refreshStatusMenuBar();
+						xmlLayout.goBack(getWindow());
 					}else if(optionName.equals("CANCEL")){
 						selectCurrentStatus();
 					}
@@ -246,11 +247,13 @@ public class FVStatusLayout_MenuBar extends MenuBar {
 			public boolean executeOption(String optionName) {
 				if(optionName != null){
 					if(optionName.equals("CLOSE")){
-//						getStatusHolder().setStatus(StatusHolderDesc.STATUS_CLOSED);
+						xmlLayout.getValidationLayout().saveAndRefreshWithoutGoBack();
 						getStatusHolder().setStatusToClosed();
-						getStatusHolder().setClosureDate(Globals.getDBManager().getCurrentTimeStamp_AsTime());
-						xmlLayout.getValidationLayout().commit();
+						getStatusHolder().setClosureDate(Globals.getDBManager().getCurrentTimeStamp_AsTime());					
+						getFocObject().validate(true);
+						
 						refreshStatusMenuBar();
+						xmlLayout.re_parseXMLAndBuildGui();
 					}else if(optionName.equals("CANCEL")){
 						selectCurrentStatus();
 					}
@@ -279,6 +282,7 @@ public class FVStatusLayout_MenuBar extends MenuBar {
 							xmlLayout.getValidationLayout().commit();
 						}
 						refreshStatusMenuBar();
+						xmlLayout.re_parseXMLAndBuildGui();
 					}else if(optionName.equals("CANCEL")){
 						selectCurrentStatus();
 					}
@@ -307,6 +311,7 @@ public class FVStatusLayout_MenuBar extends MenuBar {
 							xmlLayout.getValidationLayout().commit();
 						}
 						refreshStatusMenuBar();
+						xmlLayout.re_parseXMLAndBuildGui();
 					}else if(optionName.equals("CANCEL")){
 						selectCurrentStatus();
 					}

--- a/focWebServer/src/com/foc/web/modules/workflow/Workflow_Cancel_Form.java
+++ b/focWebServer/src/com/foc/web/modules/workflow/Workflow_Cancel_Form.java
@@ -8,14 +8,11 @@ import com.foc.business.workflow.implementation.IWorkflow;
 import com.foc.business.workflow.implementation.Workflow;
 import com.foc.desc.FocObject;
 import com.foc.util.Utils;
-import com.foc.vaadin.gui.components.FVButton;
 import com.foc.vaadin.gui.layouts.validationLayout.FVStatusLayout;
-import com.foc.vaadin.gui.layouts.validationLayout.FVStatusLayout_ComboBox;
 import com.foc.vaadin.gui.layouts.validationLayout.FVStatusLayout_MenuBar;
 import com.foc.vaadin.gui.layouts.validationLayout.FVValidationLayout;
 import com.foc.vaadin.gui.xmlForm.FocXMLLayout;
 import com.foc.vaadin.gui.xmlForm.IValidationListener;
-import com.vaadin.ui.Button.ClickListener;
 
 @SuppressWarnings("serial")
 public class Workflow_Cancel_Form extends FocXMLLayout{
@@ -153,9 +150,17 @@ public class Workflow_Cancel_Form extends FocXMLLayout{
 				
 				@Override
 				public void validationAfter(FVValidationLayout validationLayout, boolean commited) {
-			  	if(getFocXMLLayout() != null) {
-			  		getFocXMLLayout().goBack(null);
-			  	}
+					if(commited) {
+						if(getFocXMLLayout() != null) {
+							getFocXMLLayout().re_parseXMLAndBuildGui();
+							if(getFocXMLLayout().getValidationLayout() != null) {
+								FVStatusLayout_MenuBar statusLayout = getFocXMLLayout().getValidationLayout().getStatusLayout(false);
+								if(statusLayout != null) {
+									statusLayout.refreshStatusMenuBar();
+								}
+							}
+						}
+					}
 				}
 			});
 		}


### PR DESCRIPTION
When we Cancel, Close, or Reset to Approval or Proposal, We reparse the
XML and rebuild the GUI. This will adjust the editable status