### PR TITLE
When the Status component does not have any items all the component is

### DIFF
--- a/focWebServer/src/com/foc/vaadin/gui/layouts/validationLayout/FVStatusLayout_MenuBar.java
+++ b/focWebServer/src/com/foc/vaadin/gui/layouts/validationLayout/FVStatusLayout_MenuBar.java
@@ -103,16 +103,18 @@ public class FVStatusLayout_MenuBar extends MenuBar {
 				getRootMenuItem().addItem(ITEM_TITLE_RESET_TO_APPROVED, iconResource, statusMenuItemClicKListener);
 			}
 		}
-//		if(allowModification && FocWebApplication.getFocUser().getGroup().allowStatusManualModif()){
 	}
 	
 	private void selectCurrentStatus() {
 		FProperty property = focObject != null ? (FProperty) focObject.iFocData_getDataByPath(StatusHolderDesc.FNAME_STATUS) : null;
-		if(property != null){
-			getRootMenuItem().setText(property.getString());
+		if(property != null && getRootMenuItem() != null){
 			FontAwesome iconResource = FontAwesome.valueOf(StatusHolderDesc.getFontAwesomeIconNameForValue(property.getInteger()));
+
+			if(getRootMenuItem().getSize() <= 0) {
+				getRootMenuItem().addItem(property.getString(), iconResource, null);
+			}
+			getRootMenuItem().setText(property.getString());
 			getRootMenuItem().setIcon(iconResource);
-//			addStatusIfNeededAndSelectIt(property);
 		}
 	}
 	


### PR DESCRIPTION
not shown in the Form. Fixed by adding a dummy item = the the selected
item when there is no item at all.