### PR TITLE
Correction of the Bug: Redirection of a FocObject to another FocObject

### DIFF
--- a/focDataSource_DB/src/com/foc/focDataSourceDB/FocDataSource_DB.java
+++ b/focDataSource_DB/src/com/foc/focDataSourceDB/FocDataSource_DB.java
@@ -712,9 +712,7 @@ public class FocDataSource_DB implements IFocDataSource {
   	filter.addWhereToRequest_WithoutWhere(sqlWhere, refCheck.getFocDesc());
   	SQLSelectExistance selectExistance = new SQLSelectExistance(refCheck.getFocDesc(), sqlWhere);
   	selectExistance.execute();
-  	
-  	refCheck.dispose_Content();
-  	
+  	  	
   	if(selectExistance.getExist() == SQLSelectExistance.EXIST_YES){
 	  	FocConstructor constr = new FocConstructor(refCheck.getFocDesc(), null);
 	  	FocObject newFocObject = constr.newItem();
@@ -731,6 +729,8 @@ public class FocDataSource_DB implements IFocDataSource {
 	  		Globals.logException(e);
 	  	}
   	}
+  	
+  	refCheck.dispose_Content();
   }
 
 	//-----------------------------------------------------


### PR DESCRIPTION
sets all the column value to the new object and not just the one to be
redirected